### PR TITLE
Refactor analyze_performance to make thresholds optional

### DIFF
--- a/performance_monitor.py
+++ b/performance_monitor.py
@@ -173,17 +173,20 @@ def extract_core_web_vitals(data: Dict[str, Any]) -> Dict[str, Any]:
     except Exception as e:
         return {"error": f"Failed to extract metrics: {e}"}
 
-def analyze_performance(metrics: Dict[str, Any], thresholds: Dict[str, float]) -> Dict[str, Any]:
+def analyze_performance(metrics: Dict[str, Any], thresholds: Optional[Dict[str, float]] = None) -> Dict[str, Any]:
     """
     Analyze performance metrics against defined thresholds.
     
     Args:
         metrics: Performance metrics dictionary
-        thresholds: Dictionary of performance thresholds
+        thresholds: Dictionary of performance thresholds (defaults to global PERFORMANCE_THRESHOLDS)
         
     Returns:
         Dict containing analysis results and recommendations
     """
+    if thresholds is None:
+        thresholds = PERFORMANCE_THRESHOLDS
+
     if "error" in metrics:
         return metrics
     
@@ -295,7 +298,7 @@ async def run_strategy_test(
         return None
 
     # Analyze performance
-    analysis = analyze_performance(metrics, PERFORMANCE_THRESHOLDS)
+    analysis = analyze_performance(metrics)
 
     # Display results
     score = analysis.get('overall_score', 'N/A')


### PR DESCRIPTION
Updated `analyze_performance` in `performance_monitor.py` to make the `thresholds` argument optional (defaulting to `None`, which then falls back to `PERFORMANCE_THRESHOLDS`).

This change:
1. Fixes a reported issue where `analyze_performance` was called with a single argument.
2. Simplifies the function signature and usage.
3. Updates the call site in `run_strategy_test` to use the cleaner single-argument syntax.
4. Uses `None` as the default value to avoid mutable default argument risks.

The change was verified with a script checking both backward compatibility (2 args) and new usage (1 arg).

---
*PR created automatically by Jules for task [10961127761615945206](https://jules.google.com/task/10961127761615945206) started by @MRTIBBETS*