### PR TITLE
⚡ Serve properly sized logo images via srcset

### DIFF
--- a/404.html
+++ b/404.html
@@ -40,7 +40,11 @@
   <link rel="apple-touch-icon" href="/assets/logos/mayten-lane-g-on-p-200x200.png">
   
   <link rel="preload" href="/style.css" as="style">
-  <link rel="preload" href="/assets/logos/mayten-lane-g-on-clear-1000x1000.png" as="image">
+  <link rel="preload" href="/assets/logos/mayten-lane-g-on-clear-1000x1000.png" as="image"
+    imagesrcset="/assets/logos/mayten-lane-g-on-clear-200x200.png 200w,
+                 /assets/logos/mayten-lane-g-on-clear-500x500.png 500w,
+                 /assets/logos/mayten-lane-g-on-clear-1000x1000.png 1000w"
+    imagesizes="(max-width: 600px) 80vw, 400px">
   
   <!-- Stylesheets -->
   <link rel="stylesheet" href="/style.css">
@@ -55,6 +59,10 @@
     <!-- Header section -->
     <header role="banner">
       <img src="assets/logos/mayten-lane-g-on-clear-1000x1000.png"
+           srcset="assets/logos/mayten-lane-g-on-clear-200x200.png 200w,
+                   assets/logos/mayten-lane-g-on-clear-500x500.png 500w,
+                   assets/logos/mayten-lane-g-on-clear-1000x1000.png 1000w"
+           sizes="(max-width: 600px) 80vw, 400px"
            alt="Mayten Lane logo - A startup shop for growing technology companies" 
            title="Mayten Lane" 
            class="logo" 

--- a/index.html
+++ b/index.html
@@ -52,7 +52,11 @@
 
   <!-- Resource preloading -->
   <link rel="preload" href="/style.css" as="style">
-  <link rel="preload" href="/assets/logos/mayten-lane-g-on-clear-1000x1000.png" as="image">
+  <link rel="preload" href="/assets/logos/mayten-lane-g-on-clear-1000x1000.png" as="image"
+    imagesrcset="/assets/logos/mayten-lane-g-on-clear-200x200.png 200w,
+                 /assets/logos/mayten-lane-g-on-clear-500x500.png 500w,
+                 /assets/logos/mayten-lane-g-on-clear-1000x1000.png 1000w"
+    imagesizes="(max-width: 600px) 80vw, 400px">
 
   <!-- Stylesheets -->
   <link rel="stylesheet" href="/style.css">
@@ -83,6 +87,10 @@
     <!-- Header section -->
     <header role="banner">
       <img src="assets/logos/mayten-lane-g-on-clear-1000x1000.png"
+        srcset="assets/logos/mayten-lane-g-on-clear-200x200.png 200w,
+                assets/logos/mayten-lane-g-on-clear-500x500.png 500w,
+                assets/logos/mayten-lane-g-on-clear-1000x1000.png 1000w"
+        sizes="(max-width: 600px) 80vw, 400px"
         alt="Mayten Lane logo - A startup shop for growing technology companies" title="Mayten Lane" class="logo"
         height="400" width="400" loading="eager" decoding="async">
     </header>


### PR DESCRIPTION
💡 **What:** Updated the logo `<img>` tag in `index.html` and `404.html` to use `srcset` (200w, 500w, 1000w) and `sizes` attributes. Also updated the `<link rel="preload">` tag to use `imagesrcset` and `imagesizes`.
🎯 **Why:** To improve performance by serving the appropriate image size based on the user's viewport and device pixel ratio, reducing unnecessary bandwidth usage. The preload tag update ensures the browser preloads the correct image variant, preventing double downloads of the large fallback image.
📊 **Measured Improvement:** Verified via script that the correct image variant (e.g., 500w for desktop viewport) is selected by the browser.

---
*PR created automatically by Jules for task [17288778578390189770](https://jules.google.com/task/17288778578390189770) started by @MRTIBBETS*