### PR TITLE
⚡ Fix broken social media banner link

### DIFF
--- a/404.html
+++ b/404.html
@@ -17,7 +17,7 @@
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://www.maytenlane.com/404.html">
   <meta property="og:description" content="The page you're looking for doesn't exist. Return to Mayten Lane's homepage.">
-  <meta property="og:image" content="https://www.maytenlane.com/assets/banners/banner.png">
+  <meta property="og:image" content="https://www.maytenlane.com/assets/banners/mayten-lane-banner-01-896x512.png">
   <meta property="og:site_name" content="Mayten Lane">
   <meta property="og:locale" content="en_US">
 
@@ -25,7 +25,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Page Not Found | Mayten Lane">
   <meta name="twitter:description" content="The page you're looking for doesn't exist. Return to Mayten Lane's homepage.">
-  <meta name="twitter:image" content="https://www.maytenlane.com/assets/banners/banner.png">
+  <meta name="twitter:image" content="https://www.maytenlane.com/assets/banners/mayten-lane-banner-01-896x512.png">
 
   <!-- Additional SEO and mobile optimization -->
   <meta name="theme-color" content="#668B7C">

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
   <meta property="og:url" content="https://www.maytenlane.com">
   <meta property="og:description"
     content="We specialize in establishing then scaling go-to-market, community, customer lifecycle, and business operations for early stage technology companies.">
-  <meta property="og:image" content="https://www.maytenlane.com/assets/banners/banner.png">
+  <meta property="og:image" content="https://www.maytenlane.com/assets/banners/mayten-lane-banner-01-896x512.png">
   <meta property="og:image:width" content="896">
   <meta property="og:image:height" content="512">
   <meta property="og:site_name" content="Mayten Lane">
@@ -34,7 +34,7 @@
   <meta name="twitter:title" content="Mayten Lane | A startup shop for growing technology companies">
   <meta name="twitter:description"
     content="We specialize in establishing then scaling go-to-market, community, customer lifecycle, and business operations for early stage technology companies.">
-  <meta name="twitter:image" content="https://www.maytenlane.com/assets/banners/banner.png">
+  <meta name="twitter:image" content="https://www.maytenlane.com/assets/banners/mayten-lane-banner-01-896x512.png">
   <meta name="twitter:creator" content="@maytenlane">
   <meta name="twitter:site" content="@maytenlane">
 
@@ -138,7 +138,7 @@
     "name": "Mayten Lane",
     "url": "https://www.maytenlane.com",
     "logo": "https://www.maytenlane.com/assets/logos/mayten-lane-g-on-clear-1000x1000.png",
-    "banner": "https://www.maytenlane.com/assets/banners/banner.png",
+    "banner": "https://www.maytenlane.com/assets/banners/mayten-lane-banner-01-896x512.png",
     "description": "We specialize in establishing then scaling go-to-market, community, customer lifecycle, and business operations for early stage technology companies.",
     "foundingDate": "2024",
     "founder": [


### PR DESCRIPTION
💡 **What:**
- Updated `index.html` and `404.html` to point to `assets/banners/mayten-lane-banner-01-896x512.png` instead of the non-existent `assets/banners/banner.png`.
- This affects `og:image`, `twitter:image`, and the `banner` property in the structured data.

🎯 **Why:**
- The previous image link returned a 404 error (or redirected to one), causing broken previews on social media platforms.
- This change ensures that a valid image is served, improving the professional appearance of the site when shared.

📊 **Measured Improvement:**
- Baseline: `assets/banners/banner.png` returned 404.
- Improvement: `assets/banners/mayten-lane-banner-01-896x512.png` returns 200 OK.
- Verified visually using a Playwright script that injected the meta tag values into the page for inspection.
- The `performance_monitor.py` script was attempted but could not run due to a missing API key in the environment; however, this fix is a static asset correction and does not negatively impact performance (it actually avoids a failed request).

---
*PR created automatically by Jules for task [9142931221217176039](https://jules.google.com/task/9142931221217176039) started by @MRTIBBETS*