### PR TITLE
⚡ Add explicit width/height to SVG icons to improve CLS

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
       <div class="social-media" role="navigation" aria-label="Social media and contact links">
         <a href="mailto:alexander.tibbets@gmail.com?subject=Let's%20talk%20%7C%20Mayten%20Lane" target="_blank"
           title="Email Alexander about Mayten Lane" rel="noopener noreferrer" aria-label="Send email to Alexander">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-hidden="true" class="svg-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-hidden="true" class="svg-icon">
             <path fill="currentColor"
               d="M48 64C21.5 64 0 85.5 0 112c0 15.1 7.1 29.3 19.2 38.4l217.6 163.2c11.4 8.5 27 8.5 38.4 0l217.6-163.2c12.1-9.1 19.2-23.3 19.2-38.4c0-26.5-21.5-48-48-48zM0 176v208c0 35.3 28.7 64 64 64h384c35.3 0 64-28.7 64-64V176L294.4 339.2a63.9 63.9 0 0 1-76.8 0z" />
           </svg>
@@ -109,14 +109,14 @@
         <a href="https://www.linkedin.com/company/maytenlane" target="_blank"
           title="Connect with Mayten Lane on LinkedIn" rel="noopener noreferrer"
           aria-label="Visit Mayten Lane LinkedIn page">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" role="img" aria-hidden="true" class="svg-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" width="448" height="512" viewBox="0 0 448 512" role="img" aria-hidden="true" class="svg-icon">
             <path fill="currentColor"
               d="M100.28 448H7.4V148.9h92.88zM53.79 108.1C24.09 108.1 0 83.5 0 53.8a53.79 53.79 0 0 1 107.58 0c0 29.7-24.1 54.3-53.79 54.3M447.9 448h-92.68V302.4c0-34.7-.7-79.2-48.29-79.2c-48.29 0-55.69 37.7-55.69 76.7V448h-92.78V148.9h89.08v40.8h1.3c12.4-23.5 42.69-48.3 87.88-48.3c94 0 111.28 61.9 111.28 142.3V448z" />
           </svg>
         </a>
         <a href="https://www.reddit.com/r/MaytenLane" target="_blank" title="Join Mayten Lane community on Reddit"
           rel="noopener noreferrer" aria-label="Visit Mayten Lane Reddit community">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-hidden="true" class="svg-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-hidden="true" class="svg-icon">
             <path fill="currentColor"
               d="M373 138.6c-25.2 0-46.3-17.5-51.9-41c-30.6 4.3-54.2 30.7-54.2 62.4v.2c47.4 1.8 90.6 15.1 124.9 36.3c12.6-9.7 28.4-15.5 45.5-15.5c41.3 0 74.7 33.4 74.7 74.7c0 29.8-17.4 55.5-42.7 67.5c-2.4 86.8-97 156.6-213.2 156.6S45.5 410.1 43 323.4c-25.4-11.9-43-37.7-43-67.7C0 214.4 33.4 181 74.7 181c17.2 0 33 5.8 45.7 15.6c34-21.1 76.8-34.4 123.7-36.4v-.3c0-44.3 33.7-80.9 76.8-85.5C325.8 50.2 347.2 32 373 32c29.4 0 53.3 23.9 53.3 53.3s-23.9 53.3-53.3 53.3M157.5 255.3c-20.9 0-38.9 20.8-40.2 47.9s17.1 38.1 38 38.1s36.6-9.8 37.8-36.9s-11.4-49.1-35.7-49.1zM395 303.1c-1.2-27.1-19.2-47.9-40.2-47.9s-36.9 22-35.7 49.1s16.9 36.9 37.8 36.9s39.3-11 38-38.1zm-60.1 70.8c1.5-3.6-1-7.7-4.9-8.1c-23-2.3-47.9-3.6-73.8-3.6s-50.8 1.3-73.8 3.6c-3.9.4-6.4 4.5-4.9 8.1c12.9 30.8 43.3 52.4 78.7 52.4s65.8-21.6 78.7-52.4" />
           </svg>


### PR DESCRIPTION
This change improves the performance of the Mayten Lane website by adding explicit `width` and `height` attributes to the inline SVG icons in the footer.

### 💡 What
- Added `width="512" height="512"` to the Email icon.
- Added `width="448" height="512"` to the LinkedIn icon.
- Added `width="512" height="512"` to the Reddit icon.

### 🎯 Why
- **Performance:** Explicit dimensions allow the browser to calculate the aspect ratio of the SVGs immediately, preventing layout shifts (CLS) when the CSS loads and applies the final sizing (`height: 2rem`).
- **Best Practice:** Google PageSpeed Insights and modern web performance guidelines recommend explicit width and height on all image elements, including SVGs.

### 📊 Measured Improvement
- **Verification:** A Playwright script confirmed that the computed rendered size of the icons (approx. 32x32px) remains unchanged, ensuring the visual design is preserved while the underlying markup is optimized.
- **Visual Check:** Screenshot verification confirmed no visual regression.

---
*PR created automatically by Jules for task [7855927472860761832](https://jules.google.com/task/7855927472860761832) started by @MRTIBBETS*