### PR TITLE
⚡ optimize: offload async_print to thread pool

### DIFF
--- a/performance_monitor.py
+++ b/performance_monitor.py
@@ -67,8 +67,9 @@ API_TIMEOUT = aiohttp.ClientTimeout(total=30)
 
 
 async def async_print(*args, **kwargs):
-    """Print to stdout directly."""
-    print(*args, **kwargs)
+    """Print to stdout using a thread pool to avoid blocking."""
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, functools.partial(print, *args, **kwargs))
 
 
 # Configuration Management


### PR DESCRIPTION
Modified the `async_print` function in `performance_monitor.py` to use `run_in_executor` with `functools.partial`. This prevents the event loop from being blocked by I/O calls to `print`, improving the responsiveness of the performance monitoring script during high-throughput output.